### PR TITLE
EKS 1.29

### DIFF
--- a/odc_eks/addons.tf
+++ b/odc_eks/addons.tf
@@ -6,8 +6,8 @@ resource "aws_eks_addon" "vpc_cni" {
     addon_version = var.addon_vpccni_version
     configuration_values = var.addon_vpccni_config == null ? null : jsonencode(var.addon_vpccni_config)
 
-    resolve_conflicts_create = var.addon_vpccni_resolve_create    
-    resolve_conflicts_update = var.addon_vpccni_resolve_update    
+    resolve_conflicts_on_create = var.addon_vpccni_resolve_create    
+    resolve_conflicts_on_update = var.addon_vpccni_resolve_update    
 }
 
 resource "aws_eks_addon" "kube-proxy" {
@@ -18,8 +18,8 @@ resource "aws_eks_addon" "kube-proxy" {
     addon_version = var.addon_kubeproxy_version
     configuration_values = var.addon_kubeproxy_config == null ? null : jsonencode(var.addon_kubeproxy_config)
 
-    resolve_conflicts_create = var.addon_kubeproxy_resolve_create    
-    resolve_conflicts_update = var.addon_kubeproxy_resolve_update
+    resolve_conflicts_on_create = var.addon_kubeproxy_resolve_create    
+    resolve_conflicts_on_update = var.addon_kubeproxy_resolve_update
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -30,6 +30,6 @@ resource "aws_eks_addon" "coredns" {
     addon_version = var.addon_coredns_version
     configuration_values = var.addon_coredns_config == null ? null : jsonencode(var.addon_coredns_config)
 
-    resolve_conflicts_create = var.addon_coredns_resolve_create
-    resolve_conflicts_update = var.addon_coredns_resolve_update
+    resolve_conflicts_on_create = var.addon_coredns_resolve_create
+    resolve_conflicts_on_update = var.addon_coredns_resolve_update
 }

--- a/odc_eks/addons.tf
+++ b/odc_eks/addons.tf
@@ -6,9 +6,8 @@ resource "aws_eks_addon" "vpc_cni" {
     addon_version = var.addon_vpccni_version
     configuration_values = var.addon_vpccni_config == null ? null : jsonencode(var.addon_vpccni_config)
 
-    # This will change to resolve_conflicts_{create,update} using separate vars
-    # when we upgrade to aws provider v5.
-    resolve_conflicts = var.addon_vpccni_resolve_update
+    resolve_conflicts_create = var.addon_vpccni_resolve_create    
+    resolve_conflicts_update = var.addon_vpccni_resolve_update    
 }
 
 resource "aws_eks_addon" "kube-proxy" {
@@ -19,9 +18,8 @@ resource "aws_eks_addon" "kube-proxy" {
     addon_version = var.addon_kubeproxy_version
     configuration_values = var.addon_kubeproxy_config == null ? null : jsonencode(var.addon_kubeproxy_config)
 
-    # This will change to resolve_conflicts_{create,update} using separate vars
-    # when we upgrade to aws provider v5.
-    resolve_conflicts = var.addon_kubeproxy_resolve_update
+    resolve_conflicts_create = var.addon_kubeproxy_resolve_create    
+    resolve_conflicts_update = var.addon_kubeproxy_resolve_update
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -32,7 +30,6 @@ resource "aws_eks_addon" "coredns" {
     addon_version = var.addon_coredns_version
     configuration_values = var.addon_coredns_config == null ? null : jsonencode(var.addon_coredns_config)
 
-    # This will change to resolve_conflicts_{create,update} using separate vars
-    # when we upgrade to aws provider v5.
-    resolve_conflicts = var.addon_coredns_resolve_update
+    resolve_conflicts_create = var.addon_coredns_resolve_create
+    resolve_conflicts_update = var.addon_coredns_resolve_update
 }

--- a/odc_eks/variables.tf
+++ b/odc_eks/variables.tf
@@ -28,7 +28,7 @@ variable "cluster_id" {
 variable "cluster_version" {
   description = "EKS Cluster version to use"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 
 variable "admin_access_CIDRs" {
@@ -391,7 +391,7 @@ variable "addon_vpccni_enable" {
 variable "addon_vpccni_version" {
   description = "Version of the vpc-cni add-on to use, defaults to latest."
   type        = string
-  default     = "v1.18.2-eksbuild.1"
+  default     = "v1.18.6-eksbuild.1"
 }
 
 variable "addon_vpccni_resolve_create" {
@@ -435,7 +435,7 @@ variable "addon_kubeproxy_enable" {
 variable "addon_kubeproxy_version" {
   description = "Version of the kube-proxy add-on to use, defaults to latest."
   type        = string
-  default     = "v1.28.8-eksbuild.5"
+  default     = "v1.29.9-eksbuild.1"
 }
 
 variable "addon_kubeproxy_resolve_create" {
@@ -475,7 +475,7 @@ variable "addon_coredns_enable" {
 variable "addon_coredns_version" {
   description = "Version of the coredns add-on to use, defaults to latest."
   type        = string
-  default     = "v1.10.1-eksbuild.11"
+  default     = "v1.11.3-eksbuild.2"
 }
 
 variable "addon_coredns_resolve_create" {

--- a/odc_eks/versions.tf
+++ b/odc_eks/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
+      version               = ">=5"
       configuration_aliases = [aws.us-east-1]
     }
   }


### PR DESCRIPTION
# Why this change is needed
Required to support EKS 1.29


# Negative effects of this change
AWS provider v5+ is required
